### PR TITLE
Windows

### DIFF
--- a/docs/manual/conf.py
+++ b/docs/manual/conf.py
@@ -83,7 +83,7 @@ else:
         exec(code, namespace, namespace)
         return namespace
 
-    mod_path = os.path.join(os.path.dirname(__file__), "quicky_index_gen.py")
+    mod_path = "/".join((os.path.dirname(__file__), "quicky_index_gen.py"))
     namespace = exec_file(mod_path)
     del mod_path
 

--- a/docs/manual/quicky_index_gen.py
+++ b/docs/manual/quicky_index_gen.py
@@ -25,8 +25,8 @@ def from_chapters():
 
     master_doc = "contents_quicky"
 
-    fn_src = os.path.join(CURRENT_DIR, "contents.rst")
-    fn_dst = os.path.join(CURRENT_DIR, "contents_quicky.rst")
+    fn_src = "/".join((CURRENT_DIR, "contents.rst"))
+    fn_dst = "/".join((CURRENT_DIR, "contents_quicky.rst"))
 
     f = open(fn_src, 'r')
     data = f.read()
@@ -65,7 +65,7 @@ def from_chapters():
     # now exclude all dirs not in chapters
     exclude_patterns.append("contents.rst")
     for fn in os.listdir(CURRENT_DIR):
-        if os.path.isdir(os.path.join(CURRENT_DIR, fn)):
+        if os.path.isdir("/".join((CURRENT_DIR, fn))):
             if fn not in quicky_chapters:
                 # print("  exclude:", fn)
                 exclude_patterns.append(fn)

--- a/modules/blendervr/console/__init__.py
+++ b/modules/blendervr/console/__init__.py
@@ -65,7 +65,7 @@ def unstripAnchor(anchor, path):
     if path is None:
         return None
     if path[1] and anchor is not None:
-        return os.path.join(anchor, path[0])
+        return "/".join((anchor, path[0]))
     return path[0]
 
 

--- a/modules/blendervr/console/console.py
+++ b/modules/blendervr/console/console.py
@@ -51,8 +51,8 @@ class Console(logic.Logic, gui.GUI):
 
         self._processor = None
 
-        self._update_loader_script = os.path.join(BlenderVR_root, 'utils',
-                                                    'update_loader.py')
+        self._update_loader_script = "/".join((BlenderVR_root, 'utils',
+                                                    'update_loader.py'))
 
         from . import profile
         self._profile = profile.Profile(profile_file)

--- a/modules/blendervr/console/logic/console.py
+++ b/modules/blendervr/console/logic/console.py
@@ -265,8 +265,8 @@ class Logic:
     def compile_BC(self):
         try:
             import compileall
-            compileall.compile_dir(os.path.join(BlenderVR_root, 'modules',
-                                                'blendervr'), quiet=True)
+            compileall.compile_dir("/".join((BlenderVR_root, 'modules',
+                                                'blendervr')), quiet=True)
         except:
             self.logger.log_traceback(False)
 
@@ -314,9 +314,9 @@ class Logic:
                     if self.profile.getValue(['files', 'processor']) != \
                                                         processor_file_name:
                         if not os.path.isfile(processor_file_name):
-                            processor_file_name = os.path.join(BlenderVR_root,
+                            processor_file_name = "/".join((BlenderVR_root,
                                                 'modules', 'blendervr',
-                                                'processor', 'default.py')
+                                                'processor', 'default.py'))
                         self.profile.setValue(['files', 'processor'],
                                                 processor_file_name)
                         self._force_processor_file(processor_file_name)

--- a/modules/blendervr/console/logic/file_name.py
+++ b/modules/blendervr/console/logic/file_name.py
@@ -50,16 +50,18 @@ class FileName:
                             (not hasattr(self, '_origin_file_name')):
             relpath = os.path.relpath(self._file_name, anchor)
             if not relpath.startswith('..'):
-                self._origin_file_name = self._file_name
-                self._file_name = relpath
+                self._origin_file_name = self._file_name.replace('\\', '/')
+                self._file_name = relpath.replace('\\', '/')
 
     def unstrip(self, anchor):
         if not self._file_name:
             return None
+
         if hasattr(self, '_origin_file_name'):
             if anchor:
-                return os.path.join(anchor, self._file_name)
+                return os.path.join(anchor, self._file_name).replace('\\', '/')
             return self._origin_file_name
+
         if anchor:
             raise Exception('Invalid apply of anchor')
         return self._file_name

--- a/modules/blendervr/console/logic/screen.py
+++ b/modules/blendervr/console/logic/screen.py
@@ -165,7 +165,8 @@ class Logic:
                     self.logger.error('Its environment variables:',
                                       self._daemon['environments'])
                 self._process = subprocess.Popen(command,
-                         env=self._daemon['environments'],
+                         # FIXME, env prevents windows from calling linux clients
+                         #env=self._daemon['environments'],
                          stdin=daemon_in,
                          stdout=daemon_out,
                          stderr=daemon_out,

--- a/modules/blendervr/console/logic/screen.py
+++ b/modules/blendervr/console/logic/screen.py
@@ -92,8 +92,8 @@ class Logic:
                          dev_type: screen_conf[dev_type],
                          'keep_focus': screen_conf['keep_focus']}
 
-        self._log_file = os.path.join(system['log']['path'],
-                                'BlenderVR_' + self.getName() + '.log')
+        self._log_file = "/".join((system['log']['path'],
+                                'BlenderVR_' + self.getName() + '.log'))
         if system['log']['clear_previous']:
             self._log_to_clear = self._log_file
         else:
@@ -125,8 +125,8 @@ class Logic:
         if login['remote_command']:
             self._daemon['command'] += shlex.split(login['remote_command'])
         self._daemon['command'].append(login['python'])
-        self._daemon['command'].append(os.path.join(system['root'],
-                                                    'utils', 'daemon.py'))
+        self._daemon['command'].append("/".join((system['root'],
+                                                    'utils', 'daemon.py')))
         self._daemon['command'].append(self._net_console)
         self._daemon['command'].append(self.getName())
 

--- a/modules/blendervr/console/qt/console.py
+++ b/modules/blendervr/console/qt/console.py
@@ -58,8 +58,8 @@ class GUI(common_GUI):
 
         # Set up the user interface from Designer.
         from ...tools import gui, getModulePath
-        self._console_ui = gui.load(os.path.join(getModulePath(), 'designer',
-                                            'console.ui'), self._window)
+        self._console_ui = gui.load("/".join((getModulePath(), 'designer',
+                                            'console.ui')), self._window)
 
         self._window.destroyed.connect(self.cb_close)
         self._console_ui.menuQuit.triggered.connect(self.cb_close)

--- a/modules/blendervr/console/qt/options.py
+++ b/modules/blendervr/console/qt/options.py
@@ -53,8 +53,8 @@ class GUI(base.Base, common_GUI):
                              'display toggle': ['options', 'toggle']})
 
         from ...tools import gui, getModulePath
-        self._options_ui = gui.load(os.path.join(getModulePath(),
-                                    'designer', 'options.ui'), self._window)
+        self._options_ui = gui.load("/".join((getModulePath(),
+                                    'designer', 'options.ui')), self._window)
 
         self._window.setWindowTitle('BlenderVR options')
 

--- a/modules/blendervr/console/qt/screen.py
+++ b/modules/blendervr/console/qt/screen.py
@@ -51,8 +51,8 @@ class GUI(common_GUI):
              'display toggle': self._profile_index + ['log', 'toggle']})
 
         from ...tools import gui, getModulePath
-        self._screen_ui = gui.load(os.path.join(getModulePath(), 'designer',
-                                                'screen.ui'), self._window)
+        self._screen_ui = gui.load("/".join((getModulePath(), 'designer',
+                                                'screen.ui')), self._window)
         self._screen_ui.std_out.clicked.connect(self.cb_toggle_stdout_state)
         self._screen_ui.std_err.clicked.connect(self.cb_toggle_stderr_state)
 

--- a/modules/blendervr/console/xml/__init__.py
+++ b/modules/blendervr/console/xml/__init__.py
@@ -80,7 +80,7 @@ class Configure(xml.sax.handler.ContentHandler, xml.sax.handler.EntityResolver, 
     def _lookForConfigurationFile(self, filename):
         if filename is not None:
             for path in self._config_paths:
-                complete_filename = os.path.join(path, filename)
+                complete_filename = os.path.join(path, filename).replace('\\', '/')
                 try:
                     file = open(complete_filename)
                 except:

--- a/modules/blendervr/console/xml/base.py
+++ b/modules/blendervr/console/xml/base.py
@@ -226,7 +226,7 @@ class XML(xml.sax.handler.ContentHandler, Base):
             locations = os.environ.get("PATH").split(os.pathsep)
             candidates = []
             for location in locations:
-                candidate = os.path.join(location, filename)
+                candidate = "/".join((location, filename))
                 if self.is_exe(candidate):
                     return candidate
         return None

--- a/modules/blendervr/console/xml/system.py
+++ b/modules/blendervr/console/xml/system.py
@@ -110,7 +110,7 @@ class log(base.mono):
         if self._clear_previous is None:
             self._clear_previous = True
         if self._path is None:
-            self._path = os.path.join(os.path.expanduser('~'), '.log', 'blender')
+            self._path = "/".join((os.path.expanduser('~'), '.log', 'blender'))
 
 
 class login(base.mono):

--- a/modules/blendervr/interactor/arc_ball/console.py
+++ b/modules/blendervr/interactor/arc_ball/console.py
@@ -128,7 +128,7 @@ elif is_console():
 
             from ..wavefront_obj import Reader
             from ...tools import getModulePath
-            self._suzanne = Reader(os.path.join(getModulePath(), 'suzanne.obj'))
+            self._suzanne = Reader("/".join((getModulePath(), 'suzanne.obj')))
 
             # Under MACOS X, QtCore.Qt.MouseButton.LeftButton is not defined !
             # So we use 1 as button

--- a/modules/blendervr/interactor/head_controlled_navigation.py
+++ b/modules/blendervr/interactor/head_controlled_navigation.py
@@ -285,8 +285,8 @@ elif is_console():
 
             self._widget = QtGui.QWidget()
             from ..tools import gui, getModulePath
-            self._ui = gui.load(os.path.join(getModulePath(), 'designer',
-                            'head_controlled_navigation.ui'), self._widget)
+            self._ui = gui.load("/".join((getModulePath(), 'designer',
+                            'head_controlled_navigation.ui')), self._widget)
             self._ui.navigation.clicked.connect(self.cb_navigation)
             self._ui.calibration.clicked.connect(self.cb_calibration)
             self._ui.home.clicked.connect(self.cb_home)

--- a/modules/blendervr/interactor/landmarks.py
+++ b/modules/blendervr/interactor/landmarks.py
@@ -125,8 +125,8 @@ elif is_console():
 
             self._widget = QtGui.QWidget()
             from ..tools import gui, getModulePath
-            self._ui = gui.load(os.path.join(getModulePath(), 'designer',
-                                            'landmark.ui'), self._widget)
+            self._ui = gui.load("/".join((getModulePath(), 'designer',
+                                            'landmark.ui')), self._widget)
             self._ui.save.clicked.connect(self.cb_save)
             self._ui.select.clicked.connect(self.cb_select)
             self._ui.remove.clicked.connect(self.cb_remove)

--- a/modules/blendervr/loader/__init__.py
+++ b/modules/blendervr/loader/__init__.py
@@ -63,6 +63,7 @@ class Creator:
             self._output_blender_file = os.path.join(
                         os.path.dirname(self._output_blender_file),
                         '.' + os.path.basename(self._output_blender_file))
+        self._output_blender_file = self._output_blender_file.replace('\\', '/')
 
     def process(self):
         if is_creating_loader():
@@ -127,7 +128,7 @@ class Creator:
     def _getScreenShader(self):
         import os
         folderpath = os.path.dirname(os.path.abspath(__file__))
-        filepath = os.path.join(folderpath, 'oculus_dk2.glsl')
+        filepath = "/".join((folderpath, 'oculus_dk2.glsl'))
         f = open(filepath, 'r')
         data = f.read()
         f.close()

--- a/modules/blendervr/loader/__init__.py
+++ b/modules/blendervr/loader/__init__.py
@@ -59,10 +59,10 @@ class Creator:
         self._output_blender_file = self._input_blender_file.split('.')
         self._output_blender_file.insert(-1, 'vr')
         self._output_blender_file = '.'.join(self._output_blender_file)
-        if not sys.platform.startswith('win'):
-            self._output_blender_file = os.path.join(
-                        os.path.dirname(self._output_blender_file),
-                        '.' + os.path.basename(self._output_blender_file))
+        self._output_blender_file = os.path.join(
+                    os.path.dirname(self._output_blender_file),
+                    '.' + os.path.basename(self._output_blender_file))
+
         self._output_blender_file = self._output_blender_file.replace('\\', '/')
 
     def process(self):

--- a/modules/blendervr/player/splash.py
+++ b/modules/blendervr/player/splash.py
@@ -69,8 +69,8 @@ ECG_VALUES = [2.2115759e+00, 1.9184524e+00, 1.6262298e+00, 1.3363817e+00,
 class Splash(base.Base):
     def __init__(self, parent):
         super(Splash, self).__init__(parent)
-        utils_path = os.path.join(BlenderVR_root, 'utils')
-        font_path = os.path.join(utils_path, 'font.ttf')
+        utils_path = "/".join((BlenderVR_root, 'utils'))
+        font_path = "/".join((utils_path, 'font.ttf'))
         self._font_id = blf.load(font_path)
         self._ecg_values = ECG_VALUES
         self._message = ''
@@ -85,7 +85,7 @@ class Splash(base.Base):
         if self._official_splash:
             return
 
-        logo_path = os.path.join(utils_path, 'bvr-logo.ppm')
+        logo_path = "/".join((utils_path, 'bvr-logo.ppm'))
         logofile = open(logo_path, 'r')
         magic = logofile.readline().strip()
         if magic != 'P3': # check for plain ppm format

--- a/modules/blendervr/plugins/oculus_dk2/virtual_environment/__init__.py
+++ b/modules/blendervr/plugins/oculus_dk2/virtual_environment/__init__.py
@@ -133,7 +133,7 @@ class OculusDK2(base.Base):
         from .... import tools
 
         libs_path = tools.getLibsPath()
-        oculus_path = os.path.join(libs_path, "python-ovrsdk")
+        oculus_path = "/".join((libs_path, "python-ovrsdk"))
 
         if oculus_path not in sys.path:
             sys.path.append(oculus_path)

--- a/modules/blendervr/processor/__init__.py
+++ b/modules/blendervr/processor/__init__.py
@@ -76,7 +76,7 @@ def getProcessor():
         _logger.warning('Invalid path for processor: ', module_path)
         return Processor
 
-    module_name = os.path.splitext(os.path.basename(processor_file))[0]
+    module_name = os.path.splitext(os.path.basename(processor_file))[0].replace('\\', '/')
     try:
         import imp
         (file, file_name, data) = imp.find_module(module_name, [module_path])

--- a/modules/blendervr/processor/base.py
+++ b/modules/blendervr/processor/base.py
@@ -148,8 +148,8 @@ elif is_console():
             try:
                 from . import profile
                 self._profile = profile.Profile(
-                            os.path.join(BlenderVR_profilePath, 'processor',
-                            self._getProfileName()))
+                            "/".join((BlenderVR_profilePath, 'processor',
+                            self._getProfileName())))
             except:
                 self._profile = None
 

--- a/modules/blendervr/tools/__init__.py
+++ b/modules/blendervr/tools/__init__.py
@@ -61,4 +61,4 @@ def getLibsPath():
     """The path for the external libs"""
     import os
     root_path = getRootPath()
-    return os.path.join(root_path, "libs")
+    return "/".join((root_path, "libs"))

--- a/utils/console.py
+++ b/utils/console.py
@@ -52,7 +52,7 @@ def main():
     import builtins
     builtins.BlenderVR_QT = BlenderVR_QT
 
-    sys.path.append(os.path.join(BlenderVR_root, 'modules'))
+    sys.path.append("/".join((BlenderVR_root, 'modules')))
 
     if __main__.environments.d_version:
         try:

--- a/utils/daemon.py
+++ b/utils/daemon.py
@@ -154,8 +154,8 @@ class Daemon:
             if argument:
                 try:
                     import compileall
-                    compileall.compile_dir(os.path.join(BlenderVR_modules,
-                                                'blendervr'), quiet=True)
+                    compileall.compile_dir("/".join((BlenderVR_modules,
+                                                'blendervr')), quiet=True)
                 except:
                     pass
                 self._start_blender_player()
@@ -307,7 +307,7 @@ def main():
 
     # Find the installation root, and make blender package available.
     BlenderVR_root = os.path.dirname(os.path.dirname(__file__))
-    BlenderVR_modules = os.path.join(BlenderVR_root, 'modules')
+    BlenderVR_modules = "/".join((BlenderVR_root, 'modules'))
     sys.path.append(BlenderVR_modules)
 
     Daemon(BlenderVR_modules).main()

--- a/utils/update_loader.py
+++ b/utils/update_loader.py
@@ -15,7 +15,7 @@ import os
 import builtins
 
 builtins.BlenderVR_root = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(os.path.join(BlenderVR_root, 'modules'))
+sys.path.append("/".join((BlenderVR_root, 'modules')))
 
 import blendervr.tools.logger
 logger = blendervr.tools.logger.getLogger('loader creation')


### PR DESCRIPTION
This 3 patches solves the problems I was having with mixing windows and unix machines in the same BlenderVR setup:

1. Replaces all the calls to os.path.join to "/".join. This prevents mixed / \\ in the same filepath.

2. Remove 'env' from subprocess

3. Have both Windows and Unix to name their vr files with the period.

The only change I'm not sure about is the second. It would be nice to know why we were passing the env in the first place, to make sure things are still working.
